### PR TITLE
Fix for passing along operationName and variables to query execution

### DIFF
--- a/src/Framework/GraphQlQueryHandler.php
+++ b/src/Framework/GraphQlQueryHandler.php
@@ -166,11 +166,11 @@ class GraphQlQueryHandler implements GraphQlQueryHandlerInterface
 
         $graphQL = new \GraphQL\GraphQL();
         $variables = null;
-        if (in_array('variables', $queryData)) {
+        if (isset($queryData['variables'])) {
             $variables = (array) $queryData['variables'];
         }
         $operationName = null;
-        if (in_array('operationName', $queryData)) {
+        if (isset($queryData['operationName'])) {
             $operationName = $queryData['operationName'];
         }
         $result = $graphQL->executeQuery(


### PR DESCRIPTION
operationName and variables doesn't get assigned and passed to the query execution hence breaking named queries/variables.

Example:
Named query:
```
query MyQueryName {
  articles {
    title
  }
}
```
Error:
`{"errors":[{"message":"Must provide operation name if query contains multiple operations.","category":"graphql"}]}`